### PR TITLE
Add support for date/data encoding and decoding strategies to Firestore

### DIFF
--- a/CodableFirebase/FirestoreDecoder.swift
+++ b/CodableFirebase/FirestoreDecoder.swift
@@ -24,11 +24,13 @@ open class FirestoreDecoder {
     public init() {}
     
     open var userInfo: [CodingUserInfoKey : Any] = [:]
+    open var dateDecodingStrategy: FirebaseDecoder.DateDecodingStrategy = .deferredToDate
+    open var dataDecodingStrategy: FirebaseDecoder.DataDecodingStrategy = .deferredToData
     
     open func decode<T : Decodable>(_ type: T.Type, from container: [String: Any]) throws -> T {
         let options = _FirebaseDecoder._Options(
-            dateDecodingStrategy: nil,
-            dataDecodingStrategy: nil,
+            dateDecodingStrategy: dateDecodingStrategy,
+            dataDecodingStrategy: dataDecodingStrategy,
             skipFirestoreTypes: true,
             userInfo: userInfo
         )

--- a/CodableFirebase/FirestoreEncoder.swift
+++ b/CodableFirebase/FirestoreEncoder.swift
@@ -12,6 +12,8 @@ open class FirestoreEncoder {
     public init() {}
     
     open var userInfo: [CodingUserInfoKey : Any] = [:]
+    open var dateEncodingStrategy: FirebaseEncoder.DateEncodingStrategy = .deferredToDate
+    open var dataEncodingStrategy: FirebaseEncoder.DataEncodingStrategy = .deferredToData
     
     open func encode<Value : Encodable>(_ value: Value) throws -> [String: Any] {
         let topLevel = try encodeToTopLevelContainer(value)
@@ -27,8 +29,8 @@ open class FirestoreEncoder {
     
     internal func encodeToTopLevelContainer<Value : Encodable>(_ value: Value) throws -> Any {
         let options = _FirebaseEncoder._Options(
-            dateEncodingStrategy: nil,
-            dataEncodingStrategy: nil,
+            dateEncodingStrategy: dateEncodingStrategy,
+            dataEncodingStrategy: dataEncodingStrategy,
             skipFirestoreTypes: true,
             userInfo: userInfo
         )


### PR DESCRIPTION
Add support for date/data encoding and decoding strategies to FirestoreDecoder and FirestoreEncoder to mirror the FirebaseDecoder/FirebaseEncoder functionality