### PR TITLE
Updates flatMap to compactMap

### DIFF
--- a/CodableFirebase/Decoder.swift
+++ b/CodableFirebase/Decoder.swift
@@ -130,7 +130,7 @@ fileprivate struct _FirebaseKeyedDecodingContainer<K : CodingKey> : KeyedDecodin
     
     // MARK: - KeyedDecodingContainerProtocol Methods
     public var allKeys: [Key] {
-        return container.keys.flatMap { Key(stringValue: $0) }
+        return container.keys.compactMap { Key(stringValue: $0) }
     }
     
     public func contains(_ key: Key) -> Bool {


### PR DESCRIPTION
`flatMap` on a `Sequence` filtering `nil` values has been renamed to `compactMap` on [SE-0187](https://github.com/apple/swift-evolution/blob/master/proposals/0187-introduce-filtermap.md)