### PR TITLE
Enabling a custom decoding strategy for FirestoreDecoder *HACK*

### DIFF
--- a/CodableFirebase/Decoder.swift
+++ b/CodableFirebase/Decoder.swift
@@ -1153,7 +1153,7 @@ extension _FirebaseDecoder {
             
         case .custom(let closure):
             self.storage.push(container: value)
-            let date = try closure(self)
+            let date = try closure(self, value)
             self.storage.popContainer()
             return date
         }

--- a/CodableFirebase/FirebaseDecoder.swift
+++ b/CodableFirebase/FirebaseDecoder.swift
@@ -28,7 +28,7 @@ open class FirebaseDecoder {
         case formatted(DateFormatter)
         
         /// Decode the `Date` as a custom value decoded by the given closure.
-        case custom((_ decoder: Decoder) throws -> Date)
+        case custom((_ decoder: Decoder, _ value: Any) throws -> Date)
     }
     
     /// The strategy to use for decoding `Data` values.

--- a/CodableFirebase/FirestoreDecoder.swift
+++ b/CodableFirebase/FirestoreDecoder.swift
@@ -25,9 +25,9 @@ open class FirestoreDecoder {
     
     open var userInfo: [CodingUserInfoKey : Any] = [:]
     
-    open func decode<T : Decodable>(_ type: T.Type, from container: [String: Any]) throws -> T {
+    open func decode<T : Decodable>(_ type: T.Type, from container: [String: Any], dateDecoding: FirebaseDecoder.DateDecodingStrategy? = nil) throws -> T {
         let options = _FirebaseDecoder._Options(
-            dateDecodingStrategy: nil,
+            dateDecodingStrategy: dateDecoding ?? nil,
             dataDecodingStrategy: nil,
             skipFirestoreTypes: true,
             userInfo: userInfo


### PR DESCRIPTION
This enables an example usage as such

```
let dateDecoding = FirebaseDecoder.DateDecodingStrategy.custom({ (decoder, value) -> Date in
                        guard let timestamp =  value as? Timestamp else {
                            return Date.distantPast
                        }
                        return timestamp.dateValue()
                    })
let thing = try FirestoreDecoder().decode(Thing.self, from: document.data(), dateDecoding: dateDecoding)
```