### PR TITLE
Add support for FirTimestamp

### DIFF
--- a/CodableFirebase/FirestoreDecoder.swift
+++ b/CodableFirebase/FirestoreDecoder.swift
@@ -20,6 +20,11 @@ public protocol GeoPointType: FirestoreDecodable, FirestoreEncodable {
     init(latitude: Double, longitude: Double)
 }
 
+public protocol TimestampType: FirestoreDecodable, FirestoreEncodable {
+    init(date: Date)
+    func dateValue() -> Date
+}
+
 open class FirestoreDecoder {
     public init() {}
     
@@ -74,5 +79,17 @@ extension FirestoreDecodable {
 extension FirestoreEncodable {
     public func encode(to encoder: Encoder) throws {
         throw DocumentReferenceError.typeIsNotSupported
+    }
+}
+
+extension TimestampType {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(date: try container.decode(Date.self))
+    }
+  
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.dateValue())
     }
 }

--- a/CodableFirebaseTests/TestCodableFirebase.swift
+++ b/CodableFirebaseTests/TestCodableFirebase.swift
@@ -95,6 +95,11 @@ class TestCodableFirebase: XCTestCase {
                        expectedValue: expected,
                        dateEncodingStrategy: .secondsSince1970,
                        dateDecodingStrategy: .secondsSince1970)
+      
+        _testRoundTrip(of: TopLevelWrapper(FirTimestamp(date: Date(timeIntervalSince1970: seconds))),
+                       expectedValue: expected,
+                       dateEncodingStrategy: .secondsSince1970,
+                       dateDecodingStrategy: .secondsSince1970)
         
         _testRoundTrip(of: OptionalTopLevelWrapper(Date(timeIntervalSince1970: seconds)),
                        expectedValue: expected,
@@ -497,6 +502,22 @@ fileprivate struct Timestamp : Codable, Equatable {
     
     static func ==(_ lhs: Timestamp, _ rhs: Timestamp) -> Bool {
         return lhs.value == rhs.value
+    }
+}
+
+fileprivate struct FirTimestamp : TimestampType, Equatable {
+    let date: Date
+  
+    init(date: Date) {
+        self.date = date
+    }
+  
+    func dateValue() -> Date {
+        return date
+    }
+  
+    static func == (_ lhs: FirTimestamp, _ rhs: FirTimestamp) -> Bool {
+        return lhs.date == rhs.date
     }
 }
 


### PR DESCRIPTION
Closes #36 

This pull request now makes the `Timestamp` directly codable, so you can use just like other `Codable` types, like Double, Date etc.