### PR TITLE
Add coding and decoding for IndexSets

### DIFF
--- a/CodableFirebase/Decoder.swift
+++ b/CodableFirebase/Decoder.swift
@@ -1247,8 +1247,7 @@ extension _FirebaseDecoder {
             guard let decimal = try self.unbox(value, as: Decimal.self) else { return nil }
             decoded = decimal as! T
         } else if T.self == IndexSet.self || T.self == NSIndexSet.self {
-            guard let indexes = try self.unbox(value, as: Array<Int>.self) else { return nil }
-            decoded = IndexSet(indexes) as! T
+            decoded = value as! T
         } else if options.skipFirestoreTypes && (T.self is FirestoreDecodable.Type) {
             decoded = value as! T
         } else {

--- a/CodableFirebaseTests/TestCodableFirestore.swift
+++ b/CodableFirebaseTests/TestCodableFirestore.swift
@@ -15,6 +15,7 @@ fileprivate struct Document: Codable, Equatable {
     let numberExample: Double
     let dateExample: Date
     let arrayExample: [String]
+    let indexSetExample: IndexSet?
     let nullExample: Int?
     let objectExample: [String: String]
     
@@ -24,6 +25,7 @@ fileprivate struct Document: Codable, Equatable {
             && lhs.numberExample == rhs.numberExample
             && lhs.dateExample == rhs.dateExample
             && lhs.arrayExample == rhs.arrayExample
+            && lhs.indexSetExample == rhs.indexSetExample
             && lhs.nullExample == rhs.nullExample
             && lhs.objectExample == rhs.objectExample
     }
@@ -65,6 +67,7 @@ class TestCodableFirestore: XCTestCase {
             numberExample: 3.14159265,
             dateExample: Date(),
             arrayExample: ["hello", "world"],
+            indexSetExample: IndexSet([1, 2, 5, 9]),
             nullExample: nil,
             objectExample: ["objectExample": "one"]
         )
@@ -75,7 +78,8 @@ class TestCodableFirestore: XCTestCase {
             "numberExample": 3.14159265,
             "dateExample": model.dateExample,
             "arrayExample": ["hello", "world"],
-            "objectExample": ["objectExample": "one"]
+            "indexSetExample": IndexSet([1, 2, 5, 9]),
+            "objectExample": ["objectExample": "one"],
         ]
         
         XCTAssertEqual((try FirestoreEncoder().encode(model)) as NSDictionary, dict as NSDictionary)


### PR DESCRIPTION
This PR adds support for IndexSets which are stored as an array of ints in firebase

For instance:
```
let reminderSettings = ReminderSettings()
reminderSettings.time = 12.30
reminderSettings.daysOfTheWeek = IndexSet([1, 2, 5, 6])
```
would be stored as

```
{
    "time": 12.30,
    "daysOfTheWeek": [1, 2, 5, 6]
}
```