### PR TITLE
Make it available on Firebase Open Source site

### DIFF
--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -1,0 +1,6 @@
+{
+    "name": "CodableFirebase",
+    "type": "library",
+    "platforms": ["iOS"],
+    "content": "README.md"
+  }


### PR DESCRIPTION
First of all, thank you for making this nice library! Codable is really important for modern iOS development.

Have you ever heard about [https://firebaseopensource.com](https://firebaseopensource.com)? This is an official collection of Firebase's OSS projects and it's a pity that CodableFirebase isn't listed.

I tried to add a project metadata file [as described in firebase/firebaseopensource.com](https://github.com/firebase/firebaseopensource.com/blob/master/docs/configure-repo.md). Please let me know how you think, and hope this helps!